### PR TITLE
Add mutuallyExclusiveEnchantments config option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,15 +25,17 @@
 
     <repositories>
         <repository>
-            <id>apache.snapshots</id>
-            <url>https://repository.apache.org/snapshots/</url>
-        </repository>
-
-        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>

--- a/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
@@ -8,12 +8,11 @@ import nl.pim16aap2.armoredElytra.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.List;
 
 @SuppressWarnings({"unused", "UnusedReturnValue", "ClassCanBeRecord"})
 public class ArmoredElytraBuilder
@@ -72,15 +71,7 @@ public class ArmoredElytraBuilder
         final EnchantmentContainer enchantments = EnchantmentContainer.getEnchantments(sourceItem, plugin);
         if (enchantments.isEmpty())
             return null;
-        // Check for mutually exclusive enchantments
-        final Map<Enchantment, Integer> updatedEnchantments = new LinkedHashMap<>();
-        enchantments.forEach(enchantment -> updatedEnchantments.put(enchantment.getKey(), enchantment.getValue()));
-        for (Map.Entry<Enchantment, Integer> elytraEnchantment : EnchantmentContainer.getEnchantments(armoredElytra, plugin))
-            updatedEnchantments.keySet().removeIf(sourceEnchantment -> EnchantmentContainer.areMutuallyExclusive(sourceEnchantment, elytraEnchantment.getKey()));
-        if (updatedEnchantments.isEmpty())
-            return null;
-
-        return newBuilder().ofElytra(armoredElytra).addEnchantments(new EnchantmentContainer(updatedEnchantments, plugin)).withName(name).build();
+        return newBuilder().ofElytra(armoredElytra).addEnchantments(enchantments).withName(name).build();
     }
 
     /**

--- a/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
@@ -8,11 +8,12 @@ import nl.pim16aap2.armoredElytra.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 import javax.annotation.Nullable;
-import java.util.List;
+import java.util.*;
 
 @SuppressWarnings({"unused", "UnusedReturnValue", "ClassCanBeRecord"})
 public class ArmoredElytraBuilder
@@ -71,7 +72,15 @@ public class ArmoredElytraBuilder
         final EnchantmentContainer enchantments = EnchantmentContainer.getEnchantments(sourceItem, plugin);
         if (enchantments.isEmpty())
             return null;
-        return newBuilder().ofElytra(armoredElytra).addEnchantments(enchantments).withName(name).build();
+        // Check for mutually exclusive enchantments
+        final Map<Enchantment, Integer> updatedEnchantments = new LinkedHashMap<>();
+        enchantments.forEach(enchantment -> updatedEnchantments.put(enchantment.getKey(), enchantment.getValue()));
+        for (Map.Entry<Enchantment, Integer> elytraEnchantment : EnchantmentContainer.getEnchantments(armoredElytra, plugin))
+            updatedEnchantments.keySet().removeIf(sourceEnchantment -> EnchantmentContainer.areMutuallyExclusive(sourceEnchantment, elytraEnchantment.getKey()));
+        if (updatedEnchantments.isEmpty())
+            return null;
+
+        return newBuilder().ofElytra(armoredElytra).addEnchantments(new EnchantmentContainer(updatedEnchantments, plugin)).withName(name).build();
     }
 
     /**

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -85,7 +85,14 @@ public class ConfigLoader
             };
         String[] mutuallyExclusiveEnchantmentsComment =
             {
-                "The lists of enchantments where only one is allowed."
+                "The lists of enchantments that are mutually exclusive.",
+                "Each group [] on this list is treated as mutually exclusive, so only one of them can be on an ArmoredElytra.",
+                "The default follows modern vanilla rules by making the different types of protection mutually exclusive.",
+                "If you do not want any enchantments to be mutually exclusive, replace all the entries in this list with \"[]\"",
+                "You can find supported enchantments here:",
+                "https://github.com/PimvanderLoos/ArmoredElytra/blob/master/vanillaEnchantments",
+                "If you install additional enchant plugins, you can make their enchantments mutually exclusive as well.",
+                "Just add their 'NamespacedKey'. Ask the enchantment plugin dev for more info if you need it."
             };
         String[] dropNetheriteAsChestplateComment =
             {

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -34,7 +34,7 @@ public class ConfigLoader
     private boolean useTierDurability;
     private boolean dropNetheriteAsChestplate;
     private LinkedHashSet<Enchantment> allowedEnchantments;
-    private LinkedHashSet<List<Enchantment>> mutuallyExclusiveEnchantments;
+    private List<List<Enchantment>> mutuallyExclusiveEnchantments;
     private boolean craftingInSmithingTable;
     private boolean allowUpgradeToNetherite;
     private boolean bypassWearPerm;
@@ -207,7 +207,7 @@ public class ConfigLoader
 
         defaultMutuallyExclusiveEnchantments = addNewConfigOption(config, "mutuallyExclusiveEnchantments",
                                                                   defaultMutuallyExclusiveEnchantments, mutuallyExclusiveEnchantmentsComment);
-        mutuallyExclusiveEnchantments = new LinkedHashSet<>();
+        mutuallyExclusiveEnchantments = new LinkedList<>();
         defaultMutuallyExclusiveEnchantments.forEach(this::addMutuallyExclusiveEnchantments);
 
         allowAddingEnchantments = addNewConfigOption(config, "allowAddingEnchantments", true,
@@ -391,7 +391,7 @@ public class ConfigLoader
         return allowedEnchantments;
     }
 
-    public LinkedHashSet<List<Enchantment>> getMutuallyExclusiveEnchantments()
+    public List<List<Enchantment>> getMutuallyExclusiveEnchantments()
     {
         return mutuallyExclusiveEnchantments;
     }

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -165,8 +165,7 @@ public class ConfigLoader
         // Set a default list of lists of mutually exclusive enchantments
         // Default only has a list for the protection enchantments
         List<List<String>> defaultMutuallyExclusiveEnchantments = new ArrayList<>();
-        defaultMutuallyExclusiveEnchantments.add(List.of(
-                                                         "minecraft:protection",
+        defaultMutuallyExclusiveEnchantments.add(List.of("minecraft:protection",
                                                          "minecraft:projectile_protection",
                                                          "minecraft:blast_protection",
                                                          "minecraft:fire_protection"));

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -78,8 +78,8 @@ public class ConfigLoader
             {
                 "List of enchantments that are allowed to be put on an armored elytra.",
                 "If you do not want to allow any enchantments at all, remove them all and add \"NONE\"",
-                "You can find supported enchantments here:",
-                "https://github.com/PimvanderLoos/ArmoredElytra/blob/master/vanillaEnchantments",
+                "You can find supported enchantments by running the command:",
+                "\"armoredelytra listAvailableEnchantments\" in console",
                 "If you install additional enchantment plugins, you can add their enchantments as well.",
                 "Just add their 'NamespacedKey'. Ask the enchantment plugin dev for more info if you need it."
             };
@@ -89,8 +89,8 @@ public class ConfigLoader
                 "Each group [] on this list is treated as mutually exclusive, so only one of them can be on an ArmoredElytra.",
                 "The default follows modern vanilla rules by making the different types of protection mutually exclusive.",
                 "If you do not want any enchantments to be mutually exclusive, replace all the entries in this list with \"[]\"",
-                "You can find supported enchantments here:",
-                "https://github.com/PimvanderLoos/ArmoredElytra/blob/master/vanillaEnchantments",
+                "You can find supported enchantments by running the command:",
+                "\"armoredelytra listAvailableEnchantments\" in console",
                 "If you install additional enchant plugins, you can make their enchantments mutually exclusive as well.",
                 "Just add their 'NamespacedKey'. Ask the enchantment plugin dev for more info if you need it."
             };

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -35,7 +35,6 @@ public class ConfigLoader
     private boolean dropNetheriteAsChestplate;
     private LinkedHashSet<Enchantment> allowedEnchantments;
     private LinkedHashSet<List<Enchantment>> mutuallyExclusiveEnchantments;
-    private boolean allowMultipleProtectionEnchantments;
     private boolean craftingInSmithingTable;
     private boolean allowUpgradeToNetherite;
     private boolean bypassWearPerm;
@@ -122,16 +121,6 @@ public class ConfigLoader
             {
                 "Specify a language file to be used."
             };
-        String[] allowMultipleProtectionEnchantmentsComment =
-            {
-                "Allow more than 1 type of protection enchantment on a single armored elytra. ",
-                "If true, you could have both blast protection and environmental protection at the same time.",
-                "If false, the second enchantment (while crafting) will override the first. So combining an armored",
-                "elytra that has the protection enchantment with an enchanted book that " +
-                    "has the blast protection enchantment",
-                "would result in removal of the protection enchantment and addition of the " +
-                    "blast protection enchantment."
-            };
         String[] permissionsComment =
             {
                 "Globally bypass permissions for wearing and/or crafting armored elytras.",
@@ -215,8 +204,6 @@ public class ConfigLoader
         mutuallyExclusiveEnchantments = new LinkedHashSet<>();
         defaultMutuallyExclusiveEnchantments.forEach(this::addMutuallyExclusiveEnchantments);
 
-        allowMultipleProtectionEnchantments = addNewConfigOption(config, "allowMultipleProtectionEnchantments", false,
-                                                                 allowMultipleProtectionEnchantmentsComment);
         allowAddingEnchantments = addNewConfigOption(config, "allowAddingEnchantments", true,
                                                      allowAddingEnchantmentsComment);
         allowRenaming = addNewConfigOption(config, "allowRenaming", true, allowRenamingComment);
@@ -361,11 +348,6 @@ public class ConfigLoader
     public int getFullRepairItemCount(ArmorTier armorTier)
     {
         return repairCounts[armorTier.ordinal()];
-    }
-
-    public boolean allowMultipleProtectionEnchantments()
-    {
-        return allowMultipleProtectionEnchantments;
     }
 
     public boolean allowRenaming()

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -135,7 +135,7 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
     }
 
     /**
-     * Remove any entries form the list of enchantments that are mutually exclusive to each other.
+     * Remove any entries from the list of enchantments that are mutually exclusive to each other.
      * <br>First instance of a mutually exclusive enchantment gets priority
      */
     public void filterMutuallyExclusive()

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -228,7 +228,6 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
                 combined.put(entry.getKey(), entry.getValue());
         }
 
-        ArmoredElytra.getInstance().getLogger().log(Level.INFO, combined.toString());
         return combined;
     }
 

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -120,6 +120,10 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
      */
     public void applyEnchantments(final ItemStack is)
     {
+        // Clear enchantments before applying new ones
+        for (Enchantment enchantment : is.getEnchantments().keySet())
+            is.removeEnchantment(enchantment);
+
         is.addUnsafeEnchantments(enchantments);
     }
 
@@ -224,6 +228,7 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
                 combined.put(entry.getKey(), entry.getValue());
         }
 
+        ArmoredElytra.getInstance().getLogger().log(Level.INFO, combined.toString());
         return combined;
     }
 

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -219,7 +219,13 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
         if (first == null || first.isEmpty())
             return second;
 
-        final Map<Enchantment, Integer> combined = new HashMap<>();
+        final List<Enchantment> blackList =
+                second.keySet().stream()
+                        .flatMap(ench -> getMutuallyExclusiveEnchantments(ench).stream())
+                        .toList();
+        blackList.forEach(first.keySet()::remove);
+
+        final Map<Enchantment, Integer> combined = new HashMap<>(first);
         for (Map.Entry<Enchantment, Integer> entry : second.entrySet())
         {
             // Check for enchants with higher level

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -168,8 +168,8 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
             for (Enchantment mutuallyExclusiveEnchantment : mutuallyExclusiveEnchantments) {
                 if (mutuallyExclusiveEnchantment.equals(one)) count++;
                 if (mutuallyExclusiveEnchantment.equals(two)) count++;
+                if (count > 1) return true;
             }
-            if (count > 1) return true;
         }
         return false;
     }

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -202,7 +202,7 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
         if (first == null || first.isEmpty())
             return second;
 
-        Map<Enchantment, Integer> combined = new HashMap<>(first);
+        final Map<Enchantment, Integer> combined = new HashMap<>(first);
         for (Map.Entry<Enchantment, Integer> entry : second.entrySet())
         {
             // Check for mutually exclusive enchantment (giving second entry priority)

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/EnchantmentContainer.java
@@ -210,8 +210,7 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
         for (Map.Entry<Enchantment, Integer> entry : first.entrySet())
         {
             if (disallowedEnchantments.contains(entry.getKey())) continue;
-            disallowedEnchantments.addAll(getMutuallyExclusiveEnchantments(entry.getKey()).stream()
-                    .filter(i -> !i.equals(entry.getKey())).toList());
+            disallowedEnchantments.addAll(getMutuallyExclusiveEnchantments(entry.getKey()));
             allowedEnchantments.add(entry.getKey());
             combined.put(entry.getKey(), entry.getValue());
         }
@@ -223,8 +222,7 @@ public class EnchantmentContainer implements Iterable<Map.Entry<Enchantment, Int
             if (!allowedEnchantments.contains(entry.getKey()))
             {
                 if (disallowedEnchantments.contains(entry.getKey())) continue;
-                disallowedEnchantments.addAll(getMutuallyExclusiveEnchantments(entry.getKey()).stream()
-                        .filter(i -> !i.equals(entry.getKey())).toList());
+                disallowedEnchantments.addAll(getMutuallyExclusiveEnchantments(entry.getKey()));
             }
 
             // Check for enchants with higher level


### PR DESCRIPTION
This removes the old allowMultipleProtections option and replaces it with a more customizable option.
While the default behavior is the same, it allows the user to make any enchantments mutually exclusive. This allows for better support of custom enchantment plugins.