### PR TITLE
Add support for MC 1.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>${version.spigot}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
             <version>${version.spigot}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.semver4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <version.maven.surefire>3.0.0-M5</version.maven.surefire>
 
         <version.semver4j>5.3.0</version.semver4j>
-        <version.spigot>1.17.1-R0.1-SNAPSHOT</version.spigot>
+        <version.spigot>1.20.4-R0.1-SNAPSHOT</version.spigot>
         <version.bstats>2.2.1</version.bstats>
         <version.checkstyle>9.1</version.checkstyle>
         <version.mockito>4.0.0</version.mockito>

--- a/src/main/java/nl/pim16aap2/armoredElytra/ArmoredElytra.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/ArmoredElytra.java
@@ -105,7 +105,8 @@ public class ArmoredElytra extends JavaPlugin implements Listener
             Bukkit.getPluginManager().registerEvents(creationListener, this);
             if (config.allowUpgradeToNetherite())
                 Bukkit.getPluginManager()
-                      .registerEvents(new NetheriteUpgradeListener(this, nbtEditor, durabilityManager, config), this);
+                      .registerEvents(
+                          new NetheriteUpgradeListener(this, nbtEditor, durabilityManager, config), this);
 
             if (config.dropNetheriteAsChestplate())
                 Bukkit.getPluginManager().registerEvents(new ItemDropListener(nbtEditor), this);

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/AnvilHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/AnvilHandler.java
@@ -25,14 +25,21 @@ import java.util.logging.Level;
 
 public class AnvilHandler extends ArmoredElytraHandler implements Listener
 {
-    protected AnvilHandler(ArmoredElytra plugin, boolean creationEnabled,
-                           NBTEditor nbtEditor, DurabilityManager durabilityManager, ConfigLoader config)
+    protected AnvilHandler(
+        ArmoredElytra plugin,
+        boolean creationEnabled,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         super(plugin, creationEnabled, nbtEditor, durabilityManager, config);
     }
 
-    public AnvilHandler(ArmoredElytra plugin, NBTEditor nbtEditor,
-                        DurabilityManager durabilityManager, ConfigLoader config)
+    public AnvilHandler(
+        ArmoredElytra plugin,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         super(plugin, true, nbtEditor, durabilityManager, config);
     }

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/ArmoredElytraHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/ArmoredElytraHandler.java
@@ -24,9 +24,13 @@ abstract class ArmoredElytraHandler
     protected final DurabilityManager durabilityManager;
     protected final ArmoredElytraBuilder armoredElytraBuilder;
 
-    protected ArmoredElytraHandler(ArmoredElytra plugin, boolean creationEnabled, NBTEditor nbtEditor,
-                                   DurabilityManager durabilityManager, ConfigLoader config,
-                                   ArmoredElytraBuilder armoredElytraBuilder)
+    protected ArmoredElytraHandler(
+        ArmoredElytra plugin,
+        boolean creationEnabled,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config,
+        ArmoredElytraBuilder armoredElytraBuilder)
     {
         this.plugin = plugin;
         this.creationEnabled = creationEnabled;
@@ -36,8 +40,12 @@ abstract class ArmoredElytraHandler
         this.armoredElytraBuilder = armoredElytraBuilder;
     }
 
-    protected ArmoredElytraHandler(ArmoredElytra plugin, boolean creationEnabled, NBTEditor nbtEditor,
-                                   DurabilityManager durabilityManager, ConfigLoader config)
+    protected ArmoredElytraHandler(
+        ArmoredElytra plugin,
+        boolean creationEnabled,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         this(plugin, creationEnabled, nbtEditor, durabilityManager, config,
              new ArmoredElytraBuilder(nbtEditor, durabilityManager, config, plugin));
@@ -46,10 +54,13 @@ abstract class ArmoredElytraHandler
     /**
      * Attempts to move an item to a player's inventory.
      *
-     * @param player The player to give the item to.
-     * @param item   The item to give.
-     * @param direct Whether to put it in the player's inventory. When set to false it will be put in their cursor
-     *               instead.
+     * @param player
+     *     The player to give the item to.
+     * @param item
+     *     The item to give.
+     * @param direct
+     *     Whether to put it in the player's inventory. When set to false it will be put in their cursor instead.
+     *
      * @return True if the item could be given to the player, otherwise false (e.g. when their inventory is full).
      */
     @CheckReturnValue

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/CommandHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/CommandHandler.java
@@ -16,6 +16,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.logging.Level;
@@ -26,14 +27,25 @@ public class CommandHandler implements CommandExecutor
     private static Field BY_KEY_FIELD;
     private final ArmoredElytraBuilder armoredElytraBuilder;
 
-    public CommandHandler(ArmoredElytra plugin, NBTEditor nbtEditor, DurabilityManager durabilityManager)
+    public CommandHandler(
+        ArmoredElytra plugin,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager)
     {
         this.plugin = plugin;
-        armoredElytraBuilder = new ArmoredElytraBuilder(nbtEditor, durabilityManager, plugin.getConfigLoader(), plugin);
+        armoredElytraBuilder = new ArmoredElytraBuilder(
+            nbtEditor,
+            durabilityManager,
+            plugin.getConfigLoader(),
+            plugin);
     }
 
     @Override
-    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args)
+    public boolean onCommand(
+        @Nonnull CommandSender sender,
+        @Nonnull Command cmd,
+        @Nonnull String label,
+        @Nonnull String[] args)
     {
         Player player;
 
@@ -141,8 +153,8 @@ public class CommandHandler implements CommandExecutor
                 BY_KEY_FIELD.setAccessible(true);
             }
 
-            @SuppressWarnings("unchecked") final Map<NamespacedKey, Enchantment> byKey = (Map<NamespacedKey, Enchantment>) BY_KEY_FIELD.get(
-                null);
+            @SuppressWarnings("unchecked") final Map<NamespacedKey, Enchantment> byKey =
+                (Map<NamespacedKey, Enchantment>) BY_KEY_FIELD.get(null);
 
             final StringBuilder sb = new StringBuilder("\nAvailable enchantments: \n");
             byKey.keySet().stream()

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/CommandHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/CommandHandler.java
@@ -141,15 +141,15 @@ public class CommandHandler implements CommandExecutor
                 BY_KEY_FIELD.setAccessible(true);
             }
 
-            @SuppressWarnings("unchecked")
-            final Map<NamespacedKey, Enchantment> byKey = (Map<NamespacedKey, Enchantment>) BY_KEY_FIELD.get(null);
+            @SuppressWarnings("unchecked") final Map<NamespacedKey, Enchantment> byKey = (Map<NamespacedKey, Enchantment>) BY_KEY_FIELD.get(
+                null);
 
             final StringBuilder sb = new StringBuilder("\nAvailable enchantments: \n");
             byKey.keySet().stream()
                  .map(NamespacedKey::toString).sorted()
                  .forEach(name -> sb.append("  - ").append(name).append("\n"));
 
-            Bukkit.getLogger().info(sb.toString());
+            plugin.getLogger().info(sb.toString());
         }
         catch (NoSuchFieldException | IllegalAccessException e)
         {

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/NetheriteUpgradeListener.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/NetheriteUpgradeListener.java
@@ -28,8 +28,8 @@ public class NetheriteUpgradeListener extends SmithingTableListener
         final SmithingInventory inventory = event.getInventory();
         final ItemStack[] contents = inventory.getContents();
 
-        final ItemStack itemStackA = contents[0];
-        final ItemStack itemStackB = contents[1];
+        final ItemStack itemStackA = contents[SMITHING_TABLE_INPUT_SLOT_1];
+        final ItemStack itemStackB = contents[SMITHING_TABLE_INPUT_SLOT_2];
 
         if (!validInput(itemStackA, itemStackB))
             return;

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/NetheriteUpgradeListener.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/NetheriteUpgradeListener.java
@@ -16,8 +16,11 @@ import javax.annotation.Nullable;
 
 public class NetheriteUpgradeListener extends SmithingTableListener
 {
-    public NetheriteUpgradeListener(final ArmoredElytra plugin, NBTEditor nbtEditor,
-                                    DurabilityManager durabilityManager, ConfigLoader config)
+    public NetheriteUpgradeListener(
+        ArmoredElytra plugin,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         super(plugin, false, nbtEditor, durabilityManager, config);
     }

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableCraftHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableCraftHandler.java
@@ -5,14 +5,14 @@ import nl.pim16aap2.armoredElytra.nbtEditor.DurabilityManager;
 import nl.pim16aap2.armoredElytra.nbtEditor.NBTEditor;
 import nl.pim16aap2.armoredElytra.util.ArmorTier;
 import nl.pim16aap2.armoredElytra.util.ConfigLoader;
-import nl.pim16aap2.armoredElytra.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareSmithingEvent;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.SmithingInventory;
+
+import javax.annotation.Nullable;
 
 public class SmithingTableCraftHandler extends SmithingTableListener
 {
@@ -29,32 +29,22 @@ public class SmithingTableCraftHandler extends SmithingTableListener
     public void onSmithingTableUsage(final PrepareSmithingEvent event)
     {
         final SmithingInventory inventory = event.getInventory();
-        final ItemStack[] contents = inventory.getContents();
+        final @Nullable SmithingTableInput input = SmithingTableInput.fromInventory(inventory);
 
-        final ItemStack itemStackA = contents[0];
-        final ItemStack itemStackB = contents[1];
-
-        final ArmorTier newArmorTier = getNewArmorTier(itemStackA, itemStackB);
-        if (newArmorTier == ArmorTier.NONE)
+        if (input == null || !input.isFullWithoutTemplate())
             return;
 
-        if (!plugin.playerHasCraftPerm(event.getView().getPlayer(), newArmorTier))
+        if (input.newArmorTier() == ArmorTier.NONE)
             return;
 
-        event.setResult(armoredElytraBuilder.combine(itemStackA, itemStackB, newArmorTier, null));
-    }
+        if (!plugin.playerHasCraftPerm(event.getView().getPlayer(), input.newArmorTier()))
+            return;
 
-    protected ArmorTier getNewArmorTier(ItemStack itemStackA, ItemStack itemStackB)
-    {
-        if (itemStackA == null || itemStackB == null ||
-            itemStackA.getType() != Material.ELYTRA || !Util.isChestPlate(itemStackB))
-            return ArmorTier.NONE;
-
-        return Util.armorToTier(itemStackB.getType());
+        event.setResult(armoredElytraBuilder.combine(input, null));
     }
 
     @Override
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     public void onInventoryClick(InventoryClickEvent event)
     {
         super.onInventoryClick(event);

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableCraftHandler.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableCraftHandler.java
@@ -16,13 +16,18 @@ import javax.annotation.Nullable;
 
 public class SmithingTableCraftHandler extends SmithingTableListener
 {
-    public SmithingTableCraftHandler(final ArmoredElytra plugin, NBTEditor nbtEditor,
-                                     DurabilityManager durabilityManager, ConfigLoader config)
+    public SmithingTableCraftHandler(
+        ArmoredElytra plugin,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         super(plugin, true, nbtEditor, durabilityManager, config);
+
         // Register the anvil handler with creation disabled so AEs can still be repaired and stuff.
-        Bukkit.getPluginManager()
-              .registerEvents(new AnvilHandler(plugin, false, nbtEditor, durabilityManager, config), plugin);
+        Bukkit.getPluginManager().registerEvents(
+            new AnvilHandler(plugin, false, nbtEditor, durabilityManager, config),
+            plugin);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableInput.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableInput.java
@@ -9,7 +9,10 @@ import org.bukkit.inventory.SmithingInventory;
 
 import javax.annotation.Nullable;
 
-import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.*;
+import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.HAS_TEMPLATE_SLOT;
+import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.SMITHING_TABLE_INPUT_SLOT_1;
+import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.SMITHING_TABLE_INPUT_SLOT_2;
+import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.SMITHING_TABLE_TEMPLATE_SLOT;
 
 /**
  * Represents the input of a smithing table.

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableInput.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableInput.java
@@ -1,0 +1,100 @@
+package nl.pim16aap2.armoredElytra.handlers;
+
+import nl.pim16aap2.armoredElytra.ArmoredElytra;
+import nl.pim16aap2.armoredElytra.util.ArmorTier;
+import nl.pim16aap2.armoredElytra.util.Util;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.SmithingInventory;
+
+import javax.annotation.Nullable;
+
+import static nl.pim16aap2.armoredElytra.handlers.SmithingTableListener.*;
+
+/**
+ * Represents the input of a smithing table.
+ *
+ * @param elytra
+ *     The elytra to be combined.
+ * @param combinedWith
+ *     The chestplate to be combined with the elytra.
+ * @param template
+ *     The template to be used for the combination.
+ * @param newArmorTier
+ *     The new armor tier of the resulting armored elytra.
+ */
+public record SmithingTableInput(
+    @Nullable ItemStack elytra,
+    @Nullable ItemStack combinedWith,
+    @Nullable ItemStack template,
+    ArmorTier oldArmorTier,
+    ArmorTier newArmorTier
+)
+{
+    public SmithingTableInput
+    {
+        if (elytra != null && elytra.getType() != Material.ELYTRA)
+            throw new IllegalArgumentException("Elytra must be an elytra!");
+    }
+
+    /**
+     * Checks if all the required items are present.
+     *
+     * @return True if all the required items are present, false otherwise.
+     */
+    public boolean isFull()
+    {
+        return elytra != null &&
+            combinedWith != null &&
+            (!HAS_TEMPLATE_SLOT || template != null);
+    }
+
+    /**
+     * Checks if all the required items are present, except for the template.
+     *
+     * @return True if all the required items are present, false otherwise.
+     */
+    public boolean isFullWithoutTemplate()
+    {
+        return elytra != null && combinedWith != null;
+    }
+
+    /**
+     * Creates a new {@link SmithingTableInput} from the given {@link SmithingInventory}.
+     *
+     * @param inventory
+     *     The inventory to create the {@link SmithingTableInput} from.
+     *
+     * @return The created {@link SmithingTableInput} or null if the input is invalid.
+     */
+    public static @Nullable SmithingTableInput fromInventory(SmithingInventory inventory)
+    {
+        final ItemStack[] contents = inventory.getContents();
+        @Nullable ItemStack itemStackA = contents[SMITHING_TABLE_INPUT_SLOT_1];
+        @Nullable ItemStack itemStackB = contents[SMITHING_TABLE_INPUT_SLOT_2];
+
+        // Ensure that itemStackA is the elytra.
+        if (itemStackA != null && itemStackA.getType() != Material.ELYTRA &&
+            itemStackB != null && itemStackB.getType() == Material.ELYTRA)
+        {
+            final ItemStack temp = itemStackA;
+            itemStackA = itemStackB;
+            itemStackB = temp;
+        }
+
+        if (itemStackA != null && itemStackA.getType() != Material.ELYTRA)
+            return null;
+
+        final @Nullable ItemStack template = HAS_TEMPLATE_SLOT ? contents[SMITHING_TABLE_TEMPLATE_SLOT] : null;
+        final var oldArmorTier = ArmoredElytra.getInstance().getNbtEditor().getArmorTier(itemStackA);
+        final var newArmorTier = Util.armorToTier(itemStackB);
+
+        return new SmithingTableInput(
+            itemStackA,
+            itemStackB,
+            template,
+            oldArmorTier,
+            newArmorTier
+        );
+    }
+}

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableListener.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableListener.java
@@ -170,7 +170,9 @@ abstract class SmithingTableListener extends ArmoredElytraHandler implements Lis
             smithingInventory.getItem(SMITHING_TABLE_RESULT_SLOT) == null)
             return;
 
+
         final ItemStack result = smithingInventory.getItem(SMITHING_TABLE_RESULT_SLOT);
+
         if (result == null ||
             result.getType() != Material.ELYTRA ||
             nbtEditor.getArmorTier(result) == ArmorTier.NONE)
@@ -178,15 +180,6 @@ abstract class SmithingTableListener extends ArmoredElytraHandler implements Lis
 
         if (!giveItemToPlayer(player, result, event.isShiftClick()))
             return;
-
-//        final @Nullable var template =
-//            HAS_TEMPLATE_SLOT ? smithingInventory.getItem(SMITHING_TABLE_TEMPLATE_SLOT) : null;
-//
-//        if (template != null)
-//        {
-//            template.setAmount(template.getAmount() - 1);
-//            smithingInventory.setItem(SMITHING_TABLE_TEMPLATE_SLOT, template);
-//        }
 
         smithingInventory.setItem(SMITHING_TABLE_RESULT_SLOT, null);
         smithingInventory.setItem(SMITHING_TABLE_INPUT_SLOT_1, null);

--- a/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableListener.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/handlers/SmithingTableListener.java
@@ -5,80 +5,237 @@ import nl.pim16aap2.armoredElytra.nbtEditor.DurabilityManager;
 import nl.pim16aap2.armoredElytra.nbtEditor.NBTEditor;
 import nl.pim16aap2.armoredElytra.util.ArmorTier;
 import nl.pim16aap2.armoredElytra.util.ConfigLoader;
+import nl.pim16aap2.armoredElytra.util.Util;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.SmithingInventory;
 
-import java.util.logging.Level;
+import javax.annotation.Nullable;
 
+/**
+ * Abstract class for handling smithing table events.
+ */
 abstract class SmithingTableListener extends ArmoredElytraHandler implements Listener
 {
-    protected SmithingTableListener(ArmoredElytra plugin, boolean creationEnabled,
-                                    NBTEditor nbtEditor, DurabilityManager durabilityManager, ConfigLoader config)
+    /**
+     * Whether the smithing table inventory has a slot for a template item.
+     * <p>
+     * Versions prior to 1.20 do not have this slot.
+     */
+    public static final boolean HAS_TEMPLATE_SLOT;
+
+    /**
+     * The slot in the smithing table inventory where the template item is placed.
+     * <p>
+     * This slot is -1 on versions that do not have this slot in the smithing table inventory.
+     */
+    public static final int SMITHING_TABLE_TEMPLATE_SLOT;
+
+    /**
+     * The slot in the smithing table inventory where the first input item is placed.
+     */
+    public static final int SMITHING_TABLE_INPUT_SLOT_1;
+
+    /**
+     * The slot in the smithing table inventory where the second input item is placed.
+     */
+    public static final int SMITHING_TABLE_INPUT_SLOT_2;
+
+    /**
+     * The slot in the smithing table inventory where the result is placed.
+     */
+    public static final int SMITHING_TABLE_RESULT_SLOT;
+
+    static
+    {
+        final Inventory smithingInventory = Bukkit.createInventory(null, InventoryType.SMITHING);
+        HAS_TEMPLATE_SLOT = smithingInventory.getSize() == 4;
+
+        SMITHING_TABLE_RESULT_SLOT = smithingInventory.getSize() - 1;
+
+        SMITHING_TABLE_INPUT_SLOT_2 = SMITHING_TABLE_RESULT_SLOT - 1;
+        SMITHING_TABLE_INPUT_SLOT_1 = SMITHING_TABLE_INPUT_SLOT_2 - 1;
+        SMITHING_TABLE_TEMPLATE_SLOT = HAS_TEMPLATE_SLOT ? 0 : -1;
+    }
+
+    protected SmithingTableListener(
+        ArmoredElytra plugin,
+        boolean creationEnabled,
+        NBTEditor nbtEditor,
+        DurabilityManager durabilityManager,
+        ConfigLoader config)
     {
         super(plugin, creationEnabled, nbtEditor, durabilityManager, config);
     }
 
-    protected void onInventoryClick(InventoryClickEvent event)
+    /**
+     * Attempts to insert the given {@link ItemStack} into the smithing table.
+     * <p>
+     * The source item will be inserted into the second slot if the following conditions are met:
+     * <ul>
+     *     <li>The source item is an elytra.</li>
+     *     <li>The first slot is empty or contains a chestplate.</li>
+     *     <li>The second slot is empty.</li>
+     * </ul>
+     * <p>
+     * Only 1 item will be inserted into the second slot, and the source item will have its amount reduced by 1.
+     *
+     * @param smithingInventory
+     *     The {@link SmithingInventory} to insert the item into.
+     * @param event
+     *     The {@link InventoryClickEvent} to process.
+     */
+    protected void insertElytraToSmithingTable(SmithingInventory smithingInventory, InventoryClickEvent event)
     {
-        if (!isAESmithingTableEvent(event))
-            return;
-        final SmithingInventory smithingInventory = (SmithingInventory) event.getInventory();
-        final ItemStack result = smithingInventory.getItem(2);
+        final @Nullable ItemStack cursor = event.getCursor();
+        final @Nullable ItemStack current = event.getCurrentItem();
 
-        // This cast may look unchecked, but it was checked by isSmithingTableEvent already.
-        if (!giveItemToPlayer((Player) event.getWhoClicked(), result, event.isShiftClick()))
+        final @Nullable ItemStack source =
+            cursor == null || cursor.getType() == Material.AIR ? current : cursor;
+
+        if (source == null || source.getType() != Material.ELYTRA)
             return;
-        smithingInventory.clear();
+
+        final ItemStack itemA = smithingInventory.getItem(SMITHING_TABLE_INPUT_SLOT_1);
+        if (itemA != null && !Util.isChestPlate(itemA))
+            return;
+
+        final ItemStack itemB = smithingInventory.getItem(SMITHING_TABLE_INPUT_SLOT_2);
+        if (itemB != null)
+            return;
+
+        final ItemStack newItemB = source.clone();
+        newItemB.setAmount(1);
+
+        smithingInventory.setItem(SMITHING_TABLE_INPUT_SLOT_2, newItemB);
+        source.setAmount(source.getAmount() - 1);
+        event.setCancelled(true);
     }
 
     /**
-     * Checks if an {@link InventoryClickEvent} is useful for this plugin. I.e., it is about a smithing inventory and
-     * there is an (armored) elytra involved somehow.
+     * Processes the {@link InventoryClickEvent} when the player clicks on a slot in their inventory while a smithing
+     * table is open.
+     * <p>
+     * This method will check if the player is shift-clicking, and if so, try to move the item to the smithing table if
+     * possible.
      *
-     * @param event The {@link InventoryClickEvent} which may be of use to us.
-     * @return True if this plugin can process this event further.
+     * @param event
+     *     The {@link InventoryClickEvent} to process.
+     * @param smithingInventory
+     *     The {@link SmithingInventory} that the player has open (but was not clicked).
      */
-    protected boolean isAESmithingTableEvent(final InventoryClickEvent event)
+    protected void onPlayerInventoryClick(
+        InventoryClickEvent event,
+        SmithingInventory smithingInventory)
     {
-        if (event.getRawSlot() != 2)
-            return false;
+        if (!event.isShiftClick())
+            return;
 
-        // Check if the event was a player who interacted with a smithing table.
-        final Player player = (Player) event.getWhoClicked();
-        if (event.getView().getType() != InventoryType.SMITHING)
-            return false;
+        insertElytraToSmithingTable(smithingInventory, event);
+    }
 
-        SmithingInventory smithingInventory;
-        // Try to cast inventory being used in the event to a smithing inventory.
-        // This will throw a ClassCastException when a CraftInventoryCustom is used.
-        try
-        {
-            smithingInventory = (SmithingInventory) event.getInventory();
-        }
-        catch (ClassCastException exception)
-        {
-            // Print warning to console and exit onInventoryClick event (no support for
-            // custom inventories as they are usually used for GUI's).
-            plugin.debugMsg(Level.WARNING, "Could not cast inventory to SmithingInventory for player " +
-                player.getName() + "! Armored Elytras cannot be crafted!");
-            exception.printStackTrace();
-            return false;
-        }
+    /**
+     * Processes the {@link InventoryClickEvent} when the player clicks on the result slot in a smithing table.
+     * <p>
+     * This method will check if the result is an armored elytra, and if so, give it to the player.
+     *
+     * @param event
+     *     The {@link InventoryClickEvent} to process.
+     * @param player
+     *     The {@link Player} who clicked on the result slot.
+     * @param smithingInventory
+     *     The {@link SmithingInventory} which was clicked.
+     *
+     * @throws IllegalArgumentException
+     *     if the clicked slot is not the result slot.
+     */
+    protected void onSmithingInventoryResultClick(
+        InventoryClickEvent event,
+        Player player,
+        SmithingInventory smithingInventory)
+    {
+        if (event.getSlot() != SMITHING_TABLE_RESULT_SLOT)
+            throw new IllegalArgumentException(
+                "Clicked slot must be '" + SMITHING_TABLE_RESULT_SLOT + "' but received '" + event.getSlot() + "'");
 
-        if (smithingInventory.getItem(0) == null ||
-            smithingInventory.getItem(1) == null ||
-            smithingInventory.getItem(2) == null)
-            return false;
+        if (smithingInventory.getItem(SMITHING_TABLE_INPUT_SLOT_1) == null ||
+            smithingInventory.getItem(SMITHING_TABLE_INPUT_SLOT_2) == null ||
+            smithingInventory.getItem(SMITHING_TABLE_RESULT_SLOT) == null)
+            return;
 
-        final ItemStack result = smithingInventory.getItem(2);
-        if (result == null || result.getType() != Material.ELYTRA ||
+        final ItemStack result = smithingInventory.getItem(SMITHING_TABLE_RESULT_SLOT);
+        if (result == null ||
+            result.getType() != Material.ELYTRA ||
             nbtEditor.getArmorTier(result) == ArmorTier.NONE)
-            return false;
-        return true;
+            return;
+
+        if (!giveItemToPlayer(player, result, event.isShiftClick()))
+            return;
+
+//        final @Nullable var template =
+//            HAS_TEMPLATE_SLOT ? smithingInventory.getItem(SMITHING_TABLE_TEMPLATE_SLOT) : null;
+//
+//        if (template != null)
+//        {
+//            template.setAmount(template.getAmount() - 1);
+//            smithingInventory.setItem(SMITHING_TABLE_TEMPLATE_SLOT, template);
+//        }
+
+        smithingInventory.setItem(SMITHING_TABLE_RESULT_SLOT, null);
+        smithingInventory.setItem(SMITHING_TABLE_INPUT_SLOT_1, null);
+        smithingInventory.setItem(SMITHING_TABLE_INPUT_SLOT_2, null);
+    }
+
+    /**
+     * Processes the {@link InventoryClickEvent} when the player clicks on a slot in a smithing table.
+     *
+     * @param event
+     *     The {@link InventoryClickEvent} to process.
+     * @param player
+     *     The {@link Player} who clicked on a slot in the smithing table.
+     * @param smithingInventory
+     *     The {@link SmithingInventory} which was clicked.
+     */
+    protected void onSmithingInventoryClick(
+        InventoryClickEvent event,
+        Player player,
+        SmithingInventory smithingInventory)
+    {
+        if (event.getSlot() == SMITHING_TABLE_RESULT_SLOT)
+            onSmithingInventoryResultClick(event, player, smithingInventory);
+        else if (event.getSlot() == SMITHING_TABLE_INPUT_SLOT_2)
+            insertElytraToSmithingTable(smithingInventory, event);
+    }
+
+    /**
+     * Processes the general {@link InventoryClickEvent} for this plugin.
+     * <p>
+     * This method will check if the event is fired while a smithing table is open, and if so, will call the appropriate
+     * methods to further process the event.
+     * <p>
+     * See {@link #onPlayerInventoryClick(InventoryClickEvent, SmithingInventory)} and
+     * {@link #onSmithingInventoryClick(InventoryClickEvent, Player, SmithingInventory)}.
+     *
+     * @param event
+     *     The {@link InventoryClickEvent} to process.
+     */
+    protected void onInventoryClick(InventoryClickEvent event)
+    {
+        final Player player = Util.humanEntityToPlayer(event.getWhoClicked());
+
+        if (!(player.getOpenInventory().getTopInventory() instanceof SmithingInventory smithingInventory))
+            return;
+
+        if (event.getClickedInventory() instanceof PlayerInventory)
+            onPlayerInventoryClick(event, smithingInventory);
+        else if (event.getClickedInventory() instanceof SmithingInventory clickedSmithingInventory)
+            onSmithingInventoryClick(event, player, clickedSmithingInventory);
     }
 }

--- a/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/ArmoredElytraBuilder.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.armoredElytra.nbtEditor;
 
 import nl.pim16aap2.armoredElytra.ArmoredElytra;
+import nl.pim16aap2.armoredElytra.handlers.SmithingTableInput;
 import nl.pim16aap2.armoredElytra.util.ArmorTier;
 import nl.pim16aap2.armoredElytra.util.ConfigLoader;
 import nl.pim16aap2.armoredElytra.util.EnchantmentContainer;
@@ -45,11 +46,14 @@ public class ArmoredElytraBuilder
     /**
      * Shortcut for repairing an armored elytra.
      *
-     * @param armoredElytra The armored elytra to repair.
-     * @param repairItems   The repair item(s) to use for repairing the armored elytra. It is assumed that they are of
-     *                      the correct type.
-     * @param name          The new name of the output armored elytra. When this is null, {@link
-     *                      ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     * @param armoredElytra
+     *     The armored elytra to repair.
+     * @param repairItems
+     *     The repair item(s) to use for repairing the armored elytra. It is assumed that they are of the correct type.
+     * @param name
+     *     The new name of the output armored elytra. When this is null,
+     *     {@link ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     *
      * @return The new armored elytra.
      */
     public @Nullable ItemStack repair(ItemStack armoredElytra, ItemStack repairItems, @Nullable String name)
@@ -60,10 +64,14 @@ public class ArmoredElytraBuilder
     /**
      * Shortcut for enchanting an armored elytra.
      *
-     * @param armoredElytra The armored elytra to repair.
-     * @param sourceItem    The source item from which to copy the enchantments from.
-     * @param name          The new name of the output armored elytra. When this is null, {@link
-     *                      ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     * @param armoredElytra
+     *     The armored elytra to repair.
+     * @param sourceItem
+     *     The source item from which to copy the enchantments from.
+     * @param name
+     *     The new name of the output armored elytra. When this is null,
+     *     {@link ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     *
      * @return The new armored elytra.
      */
     public @Nullable ItemStack enchant(ItemStack armoredElytra, ItemStack sourceItem, @Nullable String name)
@@ -75,15 +83,40 @@ public class ArmoredElytraBuilder
     }
 
     /**
+     * Shortcut for combining two items in a smithing table.
+     *
+     * @param input
+     *     The smithing table input.
+     * @param name
+     *     The new name of the output armored elytra. When this is null, the default name for the new tier will be
+     *     used.
+     *
+     * @return The new armored elytra.
+     */
+    public ItemStack combine(SmithingTableInput input, @Nullable String name)
+    {
+        return newBuilder()
+            .ofElytra(input.elytra())
+            .combineWith(input.combinedWith(), input.newArmorTier())
+            .withName(name)
+            .build();
+    }
+
+    /**
      * Shortcut for creating a new armored elytra from two items.
      *
-     * @param elytra    The input item. This should be an (armored) elytra.
-     * @param combiner  The item to combine with the elytra. This should either be an armored elytra of the same
-     *                  non-NONE tier as the input elytra or a chestplate.
-     * @param armorTier The armor tier of the input item. If this is not known, use {@link #combine(ItemStack,
-     *                  ItemStack, String)} instead.
-     * @param name      The new name of the output armored elytra. When this is null, {@link
-     *                  ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     * @param elytra
+     *     The input item. This should be an (armored) elytra.
+     * @param combiner
+     *     The item to combine with the elytra. This should either be an armored elytra of the same non-NONE tier as the
+     *     input elytra or a chestplate.
+     * @param armorTier
+     *     The armor tier of the input item. If this is not known, use {@link #combine(ItemStack, ItemStack, String)}
+     *     instead.
+     * @param name
+     *     The new name of the output armored elytra. When this is null,
+     *     {@link ArmoredElytra#getArmoredElytraName(ArmorTier)} is used to set the name.
+     *
      * @return The new armored elytra.
      */
     public ItemStack combine(ItemStack elytra, ItemStack combiner, ArmorTier armorTier, @Nullable String name)
@@ -102,7 +135,9 @@ public class ArmoredElytraBuilder
     /**
      * Creates a new armored elytra of a specific tier.
      *
-     * @param armorTier The tier of the new armored elytra.
+     * @param armorTier
+     *     The tier of the new armored elytra.
+     *
      * @return The new armored elytra.
      */
     public ItemStack newArmoredElytra(ArmorTier armorTier)
@@ -118,8 +153,10 @@ public class ArmoredElytraBuilder
         /**
          * Specifies the new name of the armored elytra.
          *
-         * @param name The new name of the armored elytra. When this is null (default), the default name for the new
-         *             tier will be used.
+         * @param name
+         *     The new name of the armored elytra. When this is null (default), the default name for the new tier will
+         *     be used.
+         *
          * @return The current builder step.
          */
         IStep2 withName(@Nullable String name);
@@ -127,8 +164,10 @@ public class ArmoredElytraBuilder
         /**
          * Specifies the new color of the armored elytra.
          *
-         * @param color The new color of the armored elytra. When this is null (default), the color to use is inferred
-         *              from the creation process.
+         * @param color
+         *     The new color of the armored elytra. When this is null (default), the color to use is inferred from the
+         *     creation process.
+         *
          * @return The current builder step.
          */
         IStep2 withColor(@Nullable Color color);
@@ -136,8 +175,10 @@ public class ArmoredElytraBuilder
         /**
          * Specifies the new lore of the armored elytra.
          *
-         * @param lore The new lore of the armored elytra. When this is null (default), the default lore for the new
-         *             tier will be used.
+         * @param lore
+         *     The new lore of the armored elytra. When this is null (default), the default lore for the new tier will
+         *     be used.
+         *
          * @return The current builder step.
          */
         IStep2 withLore(@Nullable List<String> lore);
@@ -147,7 +188,9 @@ public class ArmoredElytraBuilder
          * <p>
          * By default, this value is read from {@link ConfigLoader#unbreakable()}.
          *
-         * @param isUnbreakable True if the armored elytra should be unbreakable.
+         * @param isUnbreakable
+         *     True if the armored elytra should be unbreakable.
+         *
          * @return The current builder step.
          */
         IStep2 unbreakable(boolean isUnbreakable);
@@ -168,7 +211,9 @@ public class ArmoredElytraBuilder
         /**
          * Repairs the armored elytra provided as input.
          *
-         * @param count The amount of repair items to process.
+         * @param count
+         *     The amount of repair items to process.
+         *
          * @return The next step of the builder process.
          */
         IStep2 repair(int count);
@@ -176,7 +221,9 @@ public class ArmoredElytraBuilder
         /**
          * Adds a set of enchantments to the armored elytra.
          *
-         * @param enchantmentContainer The enchantments to add.
+         * @param enchantmentContainer
+         *     The enchantments to add.
+         *
          * @return The next step of the builder process.
          */
         IStep2 addEnchantments(EnchantmentContainer enchantmentContainer);
@@ -184,7 +231,9 @@ public class ArmoredElytraBuilder
         /**
          * Adds a set of enchantments to the armored elytra.
          *
-         * @param sourceItem The source item from which to take the enchantments.
+         * @param sourceItem
+         *     The source item from which to take the enchantments.
+         *
          * @return The next step of the builder process.
          */
         IStep2 addEnchantments(ItemStack sourceItem);
@@ -192,10 +241,12 @@ public class ArmoredElytraBuilder
         /**
          * Combines the input elytra with another item.
          *
-         * @param item      The item to combine with the input elytra. This can either be a chestplate or, if the input
-         *                  elytra is an armored one, another armored elytra.
-         * @param armorTier The armor tier of the input item. If this is not known, use {@link #combineWith(ItemStack)}
-         *                  instead.
+         * @param item
+         *     The item to combine with the input elytra. This can either be a chestplate or, if the input elytra is an
+         *     armored one, another armored elytra.
+         * @param armorTier
+         *     The armor tier of the input item. If this is not known, use {@link #combineWith(ItemStack)} instead.
+         *
          * @return The next step of the builder process.
          */
         IStep2 combineWith(ItemStack item, ArmorTier armorTier);
@@ -210,7 +261,9 @@ public class ArmoredElytraBuilder
         /**
          * Upgrades the elytra to a specific armor tier.
          *
-         * @param armorTier The new armor tier.
+         * @param armorTier
+         *     The new armor tier.
+         *
          * @return The next step of the builder process.
          */
         IStep2 upgradeToTier(ArmorTier armorTier);
@@ -224,8 +277,9 @@ public class ArmoredElytraBuilder
         /**
          * Use an elytra as base item to create the new armored elytra from.
          *
-         * @param elytra An itemstack that represents an elytra. It does not matter whether the elytra is armored or
-         *               not.
+         * @param elytra
+         *     An itemstack that represents an elytra. It does not matter whether the elytra is armored or not.
+         *
          * @return The next step of the builder process.
          */
         IStep1 ofElytra(ItemStack elytra);
@@ -233,7 +287,9 @@ public class ArmoredElytraBuilder
         /**
          * Creates a fresh new armored elytra of a specific tier.
          *
-         * @param armorTier The tier of the new armored elytra.
+         * @param armorTier
+         *     The tier of the new armored elytra.
+         *
          * @return The next step of the builder process.
          */
         IStep2 newItem(ArmorTier armorTier);
@@ -434,8 +490,11 @@ public class ArmoredElytraBuilder
          * <p>
          * See {@link LeatherArmorMeta#getColor()}.
          *
-         * @param itemA The first {@link ItemStack} to check.
-         * @param itemB The second {@link ItemStack} to check.
+         * @param itemA
+         *     The first {@link ItemStack} to check.
+         * @param itemB
+         *     The second {@link ItemStack} to check.
+         *
          * @return The color of the item, if it has a color, otherwise null.
          */
         private @Nullable Color getItemColor(final ItemStack itemA, final ItemStack itemB)
@@ -453,7 +512,9 @@ public class ArmoredElytraBuilder
          * <p>
          * This currently only applies to leather armor(ed elytras).
          *
-         * @param itemStack The item to analyze.
+         * @param itemStack
+         *     The item to analyze.
+         *
          * @return The color of the item, if available, otherwise null.
          */
         private @Nullable Color getItemColor(final ItemStack itemStack)

--- a/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/TrimEditor.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/nbtEditor/TrimEditor.java
@@ -1,0 +1,79 @@
+package nl.pim16aap2.armoredElytra.nbtEditor;
+
+import nl.pim16aap2.armoredElytra.ArmoredElytra;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ArmorMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+final class TrimEditor
+{
+    @SuppressWarnings("unused")
+    private static final Map<Material, TrimPattern> TRIM_PATTERN_MAP = getTrimPatternMap();
+
+    private static final NamespacedKey ARMOR_TRIM_KEY =
+        new NamespacedKey(ArmoredElytra.getInstance(), "armor_trim");
+
+    ItemMeta copyArmorTrim(ItemMeta elytraMeta, ItemStack chestplate)
+    {
+        final ArmorMeta chestplateMeta = (ArmorMeta) chestplate.getItemMeta();
+        if (chestplateMeta == null)
+            return elytraMeta;
+
+        final ArmorTrim trim = chestplateMeta.getTrim();
+        if (trim == null)
+            return elytraMeta;
+
+        final ArmorMeta armorMeta = (ArmorMeta) Bukkit.getItemFactory().getItemMeta(Material.IRON_CHESTPLATE);
+        if (armorMeta == null)
+            throw new IllegalStateException("Failed to create ArmorMeta for iron chestplate!");
+
+        armorMeta.setTrim(trim);
+
+        final var container = elytraMeta.getPersistentDataContainer();
+        container.set(ARMOR_TRIM_KEY, PersistentDataType.STRING, armorMeta.getAsString());
+        return elytraMeta;
+    }
+
+    /**
+     * Returns a map of all trim templates materials and their corresponding TrimPattern.
+     *
+     * @return A map of all trim templates materials and their corresponding TrimPattern.
+     */
+    private static Map<Material, TrimPattern> getTrimPatternMap()
+    {
+        final var templates = Tag.ITEMS_TRIM_TEMPLATES;
+        final Map<Material, TrimPattern> map = new HashMap<>(templates.getValues().size());
+
+        for (final var template : templates.getValues())
+        {
+            final String name = template.name().replace("_ARMOR_TRIM_SMITHING_TEMPLATE", "");
+            try
+            {
+                final Field patternField = TrimPattern.class.getField(name);
+                final TrimPattern pattern = (TrimPattern) patternField.get(null);
+                map.put(template, pattern);
+            }
+            catch (NoSuchFieldException | IllegalAccessException | ClassCastException e)
+            {
+                ArmoredElytra.getInstance().myLogger(
+                    Level.SEVERE, "Failed to get TrimPattern for template: '" + name + "'!");
+                //noinspection CallToPrintStackTrace
+                e.printStackTrace();
+            }
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/ConfigLoader.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.armoredElytra.util;
 
 import nl.pim16aap2.armoredElytra.ArmoredElytra;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
@@ -243,7 +242,7 @@ public class ConfigLoader
             final String[] keyParts = fullKey.strip().split(":", 2);
             if (keyParts.length < 2)
             {
-                Bukkit.getLogger().warning("\"" + fullKey + "\" is not a valid NamespacedKey!");
+                plugin.getLogger().warning("\"" + fullKey + "\" is not a valid NamespacedKey!");
                 return null;
             }
             //noinspection deprecation
@@ -251,7 +250,7 @@ public class ConfigLoader
             final Enchantment enchantment = Enchantment.getByKey(key);
             if (enchantment == null)
             {
-                Bukkit.getLogger().warning("The enchantment \"" + fullKey + "\" could not be found!");
+                plugin.getLogger().warning("The enchantment \"" + fullKey + "\" could not be found!");
                 return null;
             }
             return enchantment;
@@ -315,7 +314,7 @@ public class ConfigLoader
         }
         catch (IOException e)
         {
-            Bukkit.getLogger().log(Level.SEVERE, "Could not save config.yml! " +
+            plugin.getLogger().log(Level.SEVERE, "Could not save config.yml! " +
                 "Please contact pim16aap2 and show him the following code:");
             e.printStackTrace();
         }

--- a/src/main/java/nl/pim16aap2/armoredElytra/util/Util.java
+++ b/src/main/java/nl/pim16aap2/armoredElytra/util/Util.java
@@ -1,16 +1,20 @@
 package nl.pim16aap2.armoredElytra.util;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 public class Util
 {
@@ -35,8 +39,10 @@ public class Util
     }
 
     // Get the armor tier from a chest plate.
-    public static ArmorTier armorToTier(ItemStack itemStack)
+    public static ArmorTier armorToTier(@Nullable ItemStack itemStack)
     {
+        if (itemStack == null)
+            return ArmorTier.NONE;
         return armorToTier(itemStack.getType());
     }
 
@@ -90,6 +96,37 @@ public class Util
             // No need to handle this, this is just XMaterial complaining the material doesn't exist.
             return false;
         }
+    }
+
+    /**
+     * Converts a human entity to a player. If the human entity is not a player, it will try to get the player from the
+     * UUID of the human entity.
+     * <p>
+     * If the player is not found, an {@link NullPointerException} will be thrown.
+     *
+     * @param humanEntity
+     *     The human entity to convert.
+     *
+     * @return The player.
+     *
+     * @throws NullPointerException
+     *     If the player could not be found.
+     */
+    public static @Nonnull Player humanEntityToPlayer(HumanEntity humanEntity)
+    {
+        if (humanEntity instanceof Player player)
+            return player;
+
+        return Objects.requireNonNull(
+            Bukkit.getPlayer(humanEntity.getUniqueId()),
+            "Could not get player from human entity: '" + humanEntity + "'!");
+    }
+
+    public static @Nullable Player humanEntityToOptionalPlayer(HumanEntity humanEntity)
+    {
+        if (humanEntity instanceof Player player)
+            return player;
+        return null;
     }
 
     public static String snakeToCamelCase(String input)
@@ -175,9 +212,13 @@ public class Util
     /**
      * Ensures that a given value does not exceed the provided upper and lower bounds.
      *
-     * @param val The value to check.
-     * @param min The lower bound limit.
-     * @param max The upper bound limit.
+     * @param val
+     *     The value to check.
+     * @param min
+     *     The lower bound limit.
+     * @param max
+     *     The upper bound limit.
+     *
      * @return The value if it is bigger than min and larger than max, otherwise either min or max.
      */
     public static int between(int val, int min, int max)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: nl.pim16aap2.armoredElytra.ArmoredElytra
 version: ${project.version}
 author: pim16aap2
 softdepend: [ AdvancedEnchantments ]
-api-version: 1.13
+api-version: 1.16
 commands:
   ArmoredElytra:
     description: Give an armored elytra of the specified tier.


### PR DESCRIPTION
- Properly support the new 1.20 smithing tables for crafting new armored elytras.
- Copy armor trims from chest plates onto the armored elytras.