### PR TITLE
Add support for Portuguese language and proper Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+This is a very simple plugin that allows you to combine an elytra with a chest plate in a smithing table (or an anvil, if configured).
+
+The result will be an armored elytra.
+Armored elytras offer the same amount of protection as a diamond chest plate and they can have the same enchantments as well. This means that you can add protection, fire protection etc to the armored elytra as well.
+
+By default, you can only see the elytra when a player wears an armored elytra. However, you will be able to see both the armor and the elytra at the same time if you install THIS Fabric mod on the client!
+
+List of features:
+- Combine an elytra with any type of chest plate armor to create an armored elytra! It will have the same amount of armor as the type of armor it was combined with!
+- Supports enchantments.
+- Configurable list of allowed enchantments (and curses).
+- Configurable repair cost.
+- Permissions for giving / wearing / crafting different tiers of armored elytras.
+- Add enchantments using enchanted books.
+- Receive notification when the plugin is out-of-date.
+- Permissions support.
+- Configurable messages, elytra names and elytra lores.
+- Uninstaller for when you no longer want to use this plugin.
+
+[Spigot Page](https://www.spigotmc.org/resources/armored-elytra.47136/)

--- a/src/main/resources/pt_BR.txt
+++ b/src/main/resources/pt_BR.txt
@@ -1,0 +1,29 @@
+# This file contains all the (partial) sentences used in this plugin.
+# You can change which file will be used in the config.yml.
+# The format is "key=value" (without quotation marks). You can modify the values, but not the keys.
+# Order doesn't matter and you can use comments if you so desire.
+# Please do note that white space does matter! (so spaces at the end of lines, for example).
+# The long names (without 'SHORT') are the names the elytras will have.
+TIER.Leather=&2Élitros com Armadura de Couro
+TIER.Gold=&EÉlitros com Armadura de Ouro
+TIER.Chain=&8Élitros com Armadura de Malha
+TIER.Iron=&7Élitros com Armadura de Ferro
+TIER.Diamond=&BÉlitros com Armadura de Diamante
+TIER.Netherite=&4Élitros com Armadura de Netherite
+TIER.SHORT.Leather=&2Couro
+TIER.SHORT.Gold=&EOuro
+TIER.SHORT.Chain=&8Malha
+TIER.SHORT.Iron=&7Ferro
+TIER.SHORT.Diamond=&BDiamante
+TIER.SHORT.Netherite=&4Netherite
+MESSAGES.UninstallMode=&cPlugin em modo de desinstalação! Novos Élitros Armadurados não são permitidos!
+MESSAGES.UnsupportedTier=&cNão é um tipo de armadura suportado! Experimente um destes: couro, ouro, malha, ferro, diamante, netherita.
+MESSAGES.RepairNeeded=&cVocê não pode equipar este élitro! Por favor, conserte-o em uma bigorna primeiro.
+
+# The following messages support the following variables:
+# - %ARMOR_TIER% (refers to TIER.X (e.g. TIER.Leather))
+# - %ARMOR_TIER_SHORT% (refers to TIER.SHORT.X (e.g. TIER.SHORT.Leather)).
+MESSAGES.Lore=Élitro com %ARMOR_TIER_SHORT% nível de proteção.
+MESSAGES.NoGivePermission=&cVocê não tem a permissão necessária para dar %ARMOR_TIER%s.
+MESSAGES.UsageDenied=Você não tem a permissão necessária para usar a %ARMOR_TIER%!
+MESSAGES.ElytraReceived=&2Um %ARMOR_TIER% foi concedido a você!


### PR DESCRIPTION
This PR adds Brazilian Portuguese (pt-BR) translation support to the Armored Elytra plugin, making it more accessible to players from Brazil and other Portuguese-speaking communities.

Additionally, a README file has been included, containing essential information about the plugin based on its Spigot page. This provides users with a quick overview, installation instructions, and feature details directly within the repository.

### Changes

- Added full pt-BR localization file with translated messages and strings.
- Added a README.md file with information from the Spigot resource page (features, setup, and usage).

### Motivation

- Improves usability for Portuguese-speaking players.
- Enhances project documentation by consolidating details in a README for easier reference.

### Testing

- Verified that the plugin correctly loads and applies the pt-BR locale.
- Checked formatting and structure of the README for clarity and accuracy.